### PR TITLE
Use official vqf repo for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vqf"]
 	path = vqf
-	url = https://github.com/kitlith/vqf
-	branch = remove_empty_destructors
+	url = https://github.com/dlaidig/vqf
+	branch = main


### PR DESCRIPTION
I couldn't build this package with the current fork of the submodule. It seems like the "remove_empty_destructors" branch is missing in https://github.com/kitlith/vqf , it might have been removed?

The needed change has been merged to https://github.com/dlaidig/vqf anyway, and building on the main branch seem to work fine.

Great work on this. 😄 