### PR TITLE
Fix Mac OS compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vqf"]
 	path = vqf
-	url = https://github.com/kitlith/vqf
-	branch = remove_empty_destructors
+	url = https://github.com/dlaidig/vqf
+	branch = main

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ fn main() -> miette::Result<()> {
     autocxx_build::Builder::new("src/lib.rs", &["vqf/vqf/cpp/"])
         .build()?
         .file("vqf/vqf/cpp/vqf.cpp")
+        .flag_if_supported("-std=c++14")
         .compile("autocxx-vqf");
 
     println!("cargo:rerun-if-changed=src/lib.rs");


### PR DESCRIPTION
When building on Mac OS, the -std=c++14 flag needs to be enabled. On other OS's this flag is not needed, as it seems to be default there. I have only tested this on the github actions version of Mac OS, but I assume it to be true for all versions of Mac OS.